### PR TITLE
Add HitCounterHelper for web traffic tracking

### DIFF
--- a/JoyfulReaperLibrary/JRData/Web/HitCounterHelper.cs
+++ b/JoyfulReaperLibrary/JRData/Web/HitCounterHelper.cs
@@ -1,0 +1,67 @@
+﻿/*
+ * JoyfulReaperLibrary
+ * 
+ *  Copyright (c) 2026 Kyle Givler
+ * Licensed under the MIT License.
+ */
+
+using Microsoft.Data.Sqlite;
+using System;
+using System.Threading.Tasks;
+
+namespace JoyfulReaperLib.JRData.Web;
+
+public static class HitCountHelper
+{
+    private const string _visitorsSchema = @"
+        CREATE TABLE IF NOT EXISTS Visitors (
+                IpAddress TEXT PRIMARY KEY,
+                Hits INTEGER DEFAULT 1,
+                LastSeen TEXT
+            );";
+
+    private static void EnsureTableExists(SqliteConnection connection)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = _visitorsSchema;
+        cmd.ExecuteNonQuery();
+    }
+
+    public async static Task<(long totalHits, long uniqueVisitors)> ProcessHitCounts(string connectionString, string ip)
+    {
+        long totalHits = 0;
+        long uniqueVisitors = 0;
+
+        // SQLite Upsert and Count
+        using var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync();
+
+        EnsureTableExists(connection);
+
+        // Update the hit count
+        var upsertCmd = connection.CreateCommand();
+        upsertCmd.CommandText = @"
+            INSERT INTO Visitors (IpAddress, Hits, LastSeen)
+            VALUES ($ip, 1, $date)
+            ON CONFLICT(IpAddress) DO UPDATE SET
+                Hits = Hits + 1,
+                LastSeen = $date;
+        ";
+        upsertCmd.Parameters.AddWithValue("$ip", ip);
+        upsertCmd.Parameters.AddWithValue("$date", DateTime.UtcNow.ToString("o"));
+        await upsertCmd.ExecuteNonQueryAsync();
+
+        // Get Totals
+        var statsCmd = connection.CreateCommand();
+        statsCmd.CommandText = "SELECT COUNT(IpAddress), SUM(Hits) FROM Visitors;";
+        using var reader = await statsCmd.ExecuteReaderAsync();
+
+        if (await reader.ReadAsync())
+        {
+            uniqueVisitors = reader.IsDBNull(0) ? 0 : reader.GetInt64(0);
+            totalHits = reader.IsDBNull(1) ? 0 : reader.GetInt64(1);
+        }
+
+        return (totalHits, uniqueVisitors);
+    }
+}

--- a/JoyfulReaperLibrary/JoyfulReaperLib.csproj
+++ b/JoyfulReaperLibrary/JoyfulReaperLib.csproj
@@ -7,7 +7,7 @@
     <Copyright>Copyright 2022 Kyle Givler</Copyright>
     <PackageProjectUrl>https://github.com/JoyfulReaper</PackageProjectUrl>
 	<PackageId>JoyfulReaperLib</PackageId>
-	<Version>0.0.1</Version>
+	<Version>0.0.2</Version>
 	<Authors>Kyle Givler</Authors>
 	<Description>Shared utilities and data helpers.</Description>
   </PropertyGroup>


### PR DESCRIPTION
Add a new HitCounterHelper utility class that uses SQLite to track website visitors by IP address. The helper maintains a Visitors table with IP addresses, hit counts, and last seen timestamps, providing upsert functionality to increment hits for returning visitors and retrieve overall statistics. Version bumped to 0.0.2.