### PR TITLE
Update dependencies and add SQLite initializer

### DIFF
--- a/JoyfulReaperLib.Caching.Sqlite.Tests/JoyfulReaperLib.Caching.Sqlite.Tests.csproj
+++ b/JoyfulReaperLib.Caching.Sqlite.Tests/JoyfulReaperLib.Caching.Sqlite.Tests.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/JoyfulReaperLib.Sqlite/JoyfulReaperLib.Sqlite.csproj
+++ b/JoyfulReaperLib.Sqlite/JoyfulReaperLib.Sqlite.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright 2022-2026 Kyle Givler</Copyright>
     <PackageProjectUrl>https://github.com/JoyfulReaper</PackageProjectUrl>
     <PackageId>JoyfulReaperLib.Sqlite</PackageId>
-    <Version>0.0.8</Version>
+    <Version>0.0.9</Version>
     <Authors>Kyle Givler</Authors>
     <Description>Shared SQLite provider initialization and connection string helpers for JoyfulReaperLib optional packages.</Description>
   </PropertyGroup>
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.9" />
     <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="SourceGear.sqlite3" Version="3.50.4.5" />
+    <PackageReference Include="SourceGear.sqlite3" Version="3.53.3" />
   </ItemGroup>
 
 </Project>

--- a/JoyfulReaperLib.Sqlite/SqliteDatabaseInitializer.cs
+++ b/JoyfulReaperLib.Sqlite/SqliteDatabaseInitializer.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Data.Sqlite;
+
+namespace JoyfulReaperLib.Sqlite;
+
+public static class SqliteDatabaseInitializer
+{
+    public static string Initialize(
+        string dbFileName,
+        string schemaSql,
+        string? basePath = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dbFileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaSql);
+
+        SqliteProviderInitializer.Initialize();
+
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = dbFileName,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Cache = SqliteCacheMode.Shared
+        }.ToString();
+
+        connectionString = SqliteConnectionStringHelper.Resolve(connectionString, basePath);
+
+        using var connection = new SqliteConnection(connectionString);
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = schemaSql;
+        command.ExecuteNonQuery();
+
+        return connectionString;
+    }
+}

--- a/JoyfulReaperLib.WebStats.Sqlite.Tests/JoyfulReaperLib.WebStats.Sqlite.Tests.csproj
+++ b/JoyfulReaperLib.WebStats.Sqlite.Tests/JoyfulReaperLib.WebStats.Sqlite.Tests.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/JoyfulReaperLib.WebStats.Sqlite/JoyfulReaperLib.WebStats.Sqlite.csproj
+++ b/JoyfulReaperLib.WebStats.Sqlite/JoyfulReaperLib.WebStats.Sqlite.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright 2022-2026 Kyle Givler</Copyright>
     <PackageProjectUrl>https://github.com/JoyfulReaper</PackageProjectUrl>
     <PackageId>JoyfulReaperLib.WebStats.Sqlite</PackageId>
-    <Version>0.0.8</Version>
+    <Version>0.0.9</Version>
     <Authors>Kyle Givler</Authors>
     <Description>SQLite-backed reusable hit counting and web stats for JoyfulReaperLib.</Description>
   </PropertyGroup>

--- a/JoyfulReaperLibTests/JoyfulReaperLib.Tests.csproj
+++ b/JoyfulReaperLibTests/JoyfulReaperLib.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Bump MSTest.TestAdapter and MSTest.TestFramework from 4.2.3 to 4.3.0 across test projects
- Update SourceGear.sqlite3 from 3.50.4.5 to 3.53.3
- Bump JoyfulReaperLib.Sqlite and JoyfulReaperLib.WebStats.Sqlite to version 0.0.9
- Add SqliteDatabaseInitializer utility class for simplified SQLite database initialization with schema setup