### PR TITLE
Add Mission Control and ntfy integrations

### DIFF
--- a/JoyfulReaperLib.Caching.Sqlite.Tests/JoyfulReaperLib.Caching.Sqlite.Tests.csproj
+++ b/JoyfulReaperLib.Caching.Sqlite.Tests/JoyfulReaperLib.Caching.Sqlite.Tests.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/JoyfulReaperLib.MissionControl/IMissionControlClient.cs
+++ b/JoyfulReaperLib.MissionControl/IMissionControlClient.cs
@@ -1,0 +1,11 @@
+﻿namespace JoyfulReaperLib.MissionControl;
+
+public interface IMissionControlClient
+{
+    Task<bool> TryPublishAsync<TPayload>(
+        string eventType,
+        TPayload payload,
+        DateTimeOffset occurredAt,
+        string? correlationId = null,
+        CancellationToken cancellationToken = default);
+}

--- a/JoyfulReaperLib.MissionControl/JoyfulReaperLib.MissionControl.csproj
+++ b/JoyfulReaperLib.MissionControl/JoyfulReaperLib.MissionControl.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+	  <Copyright>Copyright 2026 Kyle Givler</Copyright>
+	  <PackageProjectUrl>https://github.com/JoyfulReaper</PackageProjectUrl>
+	  <PackageId>JoyfulReaperLib.MissionControl</PackageId>
+	  <Version>0.0.1</Version>
+	  <Authors>Kyle Givler</Authors>
+	  <Description>
+		  Best-effort HTTP event publishing client for Mission Control.
+	  </Description>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference
+		  Include="Microsoft.Extensions.Http"
+		  Version="10.0.9" />
+
+		<PackageReference
+		  Include="Microsoft.Extensions.Options.ConfigurationExtensions"
+		  Version="10.0.9" />
+	</ItemGroup>
+
+</Project>

--- a/JoyfulReaperLib.MissionControl/MissionControlClient.cs
+++ b/JoyfulReaperLib.MissionControl/MissionControlClient.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace JoyfulReaperLib.MissionControl;
+
+public sealed class MissionControlClient(
+    IHttpClientFactory httpClientFactory,
+    IOptions<MissionControlClientOptions> options,
+    ILogger<MissionControlClient> logger)
+    : IMissionControlClient
+{
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web);
+
+    private readonly MissionControlClientOptions _options =
+        options.Value;
+
+    public async Task<bool> TryPublishAsync<TPayload>(
+        string eventType,
+        TPayload payload,
+        DateTimeOffset occurredAt,
+        string? correlationId = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(eventType);
+        ArgumentNullException.ThrowIfNull(payload);
+
+        if (!_options.Enabled)
+        {
+            return false;
+        }
+
+        try
+        {
+            var request = new PublishEventRequest<TPayload>(
+                EventId: Guid.NewGuid(),
+                EventType: eventType,
+                SchemaVersion: 1,
+                OccurredAt: occurredAt,
+                CorrelationId: correlationId,
+                Payload: payload);
+
+            using var message = new HttpRequestMessage(
+                HttpMethod.Post,
+                "api/events");
+
+            message.Headers.TryAddWithoutValidation(
+                MissionControlClientOptions.ApiKeyHeaderName,
+                _options.ApiKey);
+
+            message.Content = JsonContent.Create(
+                request,
+                options: JsonOptions);
+
+            var client = httpClientFactory.CreateClient(
+                MissionControlClientOptions.HttpClientName);
+
+            using var response = await client.SendAsync(
+                message,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                logger.LogDebug(
+                    "Published Mission Control event {EventType}",
+                    eventType);
+
+                return true;
+            }
+
+            logger.LogWarning(
+                "Mission Control rejected event {EventType} with HTTP status {StatusCode}",
+                eventType,
+                (int)response.StatusCode);
+
+            return false;
+        }
+        catch (OperationCanceledException)
+            when (cancellationToken.IsCancellationRequested)
+        {
+            return false;
+        }
+        catch (OperationCanceledException exception)
+        {
+            logger.LogWarning(
+                exception,
+                "Mission Control event {EventType} timed out",
+                eventType);
+
+            return false;
+        }
+        catch (HttpRequestException exception)
+        {
+            logger.LogWarning(
+                exception,
+                "Mission Control was unavailable while publishing {EventType}",
+                eventType);
+
+            return false;
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(
+                exception,
+                "Unexpected error publishing Mission Control event {EventType}",
+                eventType);
+
+            return false;
+        }
+    }
+}

--- a/JoyfulReaperLib.MissionControl/MissionControlClientOptions.cs
+++ b/JoyfulReaperLib.MissionControl/MissionControlClientOptions.cs
@@ -20,4 +20,8 @@ public sealed class MissionControlClientOptions
 
     public int TimeoutMilliseconds { get; set; } =
         1000;
+
+    public string? CloudflareAccessClientId { get; set; }
+
+    public string? CloudflareAccessClientSecret { get; set; }
 }

--- a/JoyfulReaperLib.MissionControl/MissionControlClientOptions.cs
+++ b/JoyfulReaperLib.MissionControl/MissionControlClientOptions.cs
@@ -1,0 +1,23 @@
+﻿namespace JoyfulReaperLib.MissionControl;
+
+public sealed class MissionControlClientOptions
+{
+    public const string SectionName = "MissionControl";
+
+    internal const string HttpClientName =
+        "JoyfulReaperLib.MissionControl";
+
+    internal const string ApiKeyHeaderName =
+        "X-Mission-Control-Key";
+
+    public bool Enabled { get; set; }
+
+    public string BaseUrl { get; set; } =
+        "http://localhost:5190";
+
+    public string ApiKey { get; set; } =
+        string.Empty;
+
+    public int TimeoutMilliseconds { get; set; } =
+        1000;
+}

--- a/JoyfulReaperLib.MissionControl/MissionControlServiceCollectionExtensions.cs
+++ b/JoyfulReaperLib.MissionControl/MissionControlServiceCollectionExtensions.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace JoyfulReaperLib.MissionControl;
+
+public static class MissionControlServiceCollectionExtensions
+{
+    public static IServiceCollection AddMissionControlClient(
+        this IServiceCollection services,
+        IConfigurationSection configurationSection)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configurationSection);
+
+        services
+            .AddOptions<MissionControlClientOptions>()
+            .Bind(configurationSection)
+            .Validate(
+                options =>
+                    Uri.TryCreate(
+                        options.BaseUrl,
+                        UriKind.Absolute,
+                        out var uri) &&
+                    (uri.Scheme == Uri.UriSchemeHttp ||
+                     uri.Scheme == Uri.UriSchemeHttps),
+                "MissionControl:BaseUrl must be an absolute HTTP or HTTPS URL.")
+            .Validate(
+                options =>
+                    !options.Enabled ||
+                    options.ApiKey.Length >= 32,
+                "MissionControl:ApiKey must contain at least 32 characters when enabled.")
+            .Validate(
+                options =>
+                    options.TimeoutMilliseconds
+                        is >= 100 and <= 10_000,
+                "MissionControl:TimeoutMilliseconds must be between 100 and 10000.")
+            .ValidateOnStart();
+
+        services.AddHttpClient(
+            MissionControlClientOptions.HttpClientName,
+            (serviceProvider, client) =>
+            {
+                var options = serviceProvider
+                    .GetRequiredService<
+                        IOptions<MissionControlClientOptions>>()
+                    .Value;
+
+                client.BaseAddress =
+                    new Uri(options.BaseUrl, UriKind.Absolute);
+
+                client.Timeout =
+                    TimeSpan.FromMilliseconds(
+                        options.TimeoutMilliseconds);
+            });
+
+        services.AddSingleton<
+            IMissionControlClient,
+            MissionControlClient>();
+
+        return services;
+    }
+}

--- a/JoyfulReaperLib.MissionControl/MissionControlServiceCollectionExtensions.cs
+++ b/JoyfulReaperLib.MissionControl/MissionControlServiceCollectionExtensions.cs
@@ -46,6 +46,20 @@ public static class MissionControlServiceCollectionExtensions
                         IOptions<MissionControlClientOptions>>()
                     .Value;
 
+                if (!string.IsNullOrWhiteSpace(options.CloudflareAccessClientId))
+                {
+                    client.DefaultRequestHeaders.Add(
+                        "CF-Access-Client-Id",
+                        options.CloudflareAccessClientId);
+                }
+
+                if (!string.IsNullOrWhiteSpace(options.CloudflareAccessClientSecret))
+                {
+                    client.DefaultRequestHeaders.Add(
+                        "CF-Access-Client-Secret",
+                        options.CloudflareAccessClientSecret);
+                }
+
                 client.BaseAddress =
                     new Uri(options.BaseUrl, UriKind.Absolute);
 

--- a/JoyfulReaperLib.MissionControl/NullMissionControlClient.cs
+++ b/JoyfulReaperLib.MissionControl/NullMissionControlClient.cs
@@ -1,0 +1,22 @@
+﻿namespace JoyfulReaperLib.MissionControl;
+
+public sealed class NullMissionControlClient
+    : IMissionControlClient
+{
+    public static NullMissionControlClient Instance { get; } =
+        new();
+
+    private NullMissionControlClient()
+    {
+    }
+
+    public Task<bool> TryPublishAsync<TPayload>(
+        string eventType,
+        TPayload payload,
+        DateTimeOffset occurredAt,
+        string? correlationId = null,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(false);
+    }
+}

--- a/JoyfulReaperLib.MissionControl/PublishEventRequest.cs
+++ b/JoyfulReaperLib.MissionControl/PublishEventRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace JoyfulReaperLib.MissionControl;
+
+internal sealed record PublishEventRequest<TPayload>(
+    Guid EventId,
+    string EventType,
+    int SchemaVersion,
+    DateTimeOffset OccurredAt,
+    string? CorrelationId,
+    TPayload Payload);

--- a/JoyfulReaperLib.Ntfy.Tests/FakeHttpMessageHandler.cs
+++ b/JoyfulReaperLib.Ntfy.Tests/FakeHttpMessageHandler.cs
@@ -1,0 +1,39 @@
+using System.Net;
+
+namespace JoyfulReaperLib.Ntfy.Tests;
+
+internal sealed class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responseFactory;
+
+    public FakeHttpMessageHandler(
+        HttpStatusCode statusCode = HttpStatusCode.OK)
+        : this((_, _) => Task.FromResult(new HttpResponseMessage(statusCode)))
+    {
+    }
+
+    public FakeHttpMessageHandler(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responseFactory)
+    {
+        _responseFactory = responseFactory;
+    }
+
+    public HttpRequestMessage? Request { get; private set; }
+
+    public string? RequestBody { get; private set; }
+
+    public CancellationToken CancellationToken { get; private set; }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        Request = request;
+        CancellationToken = cancellationToken;
+        RequestBody = request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken);
+
+        return await _responseFactory(request, cancellationToken);
+    }
+}

--- a/JoyfulReaperLib.Ntfy.Tests/JoyfulReaperLib.Ntfy.Tests.csproj
+++ b/JoyfulReaperLib.Ntfy.Tests/JoyfulReaperLib.Ntfy.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JoyfulReaperLib.Ntfy\JoyfulReaperLib.Ntfy.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/JoyfulReaperLib.Ntfy.Tests/NtfyPublisherTests.cs
+++ b/JoyfulReaperLib.Ntfy.Tests/NtfyPublisherTests.cs
@@ -1,0 +1,197 @@
+using Microsoft.Extensions.Options;
+using System.Net;
+using System.Text.Json;
+
+namespace JoyfulReaperLib.Ntfy.Tests;
+
+[TestClass]
+public sealed class NtfyPublisherTests
+{
+    private static readonly Uri ServerUrl = new("https://ntfy.example.test/");
+
+    [TestMethod]
+    public async Task PublishAsync_SendsPostToConfiguredServerUrl()
+    {
+        var handler = new FakeHttpMessageHandler();
+        var publisher = CreatePublisher(handler);
+
+        await publisher.PublishAsync(new NtfyMessage { Message = "Hello" });
+
+        Assert.IsNotNull(handler.Request);
+        Assert.AreEqual(HttpMethod.Post, handler.Request.Method);
+        Assert.AreEqual(ServerUrl, handler.Request.RequestUri);
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_SerializesConfiguredPayload()
+    {
+        var handler = new FakeHttpMessageHandler();
+        var publisher = CreatePublisher(handler, topic: "alerts");
+        var clickUrl = new Uri("https://example.test/details?id=42");
+
+        await publisher.PublishAsync(new NtfyMessage
+        {
+            Message = "Build completed",
+            Title = "CI",
+            Priority = NtfyPriority.High,
+            Tags = ["white_check_mark", "build"],
+            ClickUrl = clickUrl
+        });
+
+        using var payload = JsonDocument.Parse(handler.RequestBody!);
+        var root = payload.RootElement;
+
+        Assert.AreEqual("alerts", root.GetProperty("topic").GetString());
+        Assert.AreEqual("Build completed", root.GetProperty("message").GetString());
+        Assert.AreEqual("CI", root.GetProperty("title").GetString());
+        Assert.AreEqual(4, root.GetProperty("priority").GetInt32());
+        CollectionAssert.AreEqual(
+            new[] { "white_check_mark", "build" },
+            root.GetProperty("tags").EnumerateArray().Select(tag => tag.GetString()).ToArray());
+        Assert.AreEqual(clickUrl.AbsoluteUri, root.GetProperty("click").GetString());
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_WithAccessToken_SendsBearerAuthorizationHeader()
+    {
+        var handler = new FakeHttpMessageHandler();
+        var publisher = CreatePublisher(handler, accessToken: "tk_exact-token");
+
+        await publisher.PublishAsync(new NtfyMessage { Message = "Hello" });
+
+        Assert.IsNotNull(handler.Request);
+        Assert.IsNotNull(handler.Request.Headers.Authorization);
+        Assert.AreEqual("Bearer", handler.Request.Headers.Authorization.Scheme);
+        Assert.AreEqual("tk_exact-token", handler.Request.Headers.Authorization.Parameter);
+    }
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("   ")]
+    public async Task PublishAsync_WithoutAccessToken_OmitsAuthorizationHeader(string? accessToken)
+    {
+        var handler = new FakeHttpMessageHandler();
+        var publisher = CreatePublisher(handler, accessToken: accessToken);
+
+        await publisher.PublishAsync(new NtfyMessage { Message = "Hello" });
+
+        Assert.IsNotNull(handler.Request);
+        Assert.IsNull(handler.Request.Headers.Authorization);
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_WithNullOptionalValues_OmitsThemFromJson()
+    {
+        var handler = new FakeHttpMessageHandler();
+        var publisher = CreatePublisher(handler);
+
+        await publisher.PublishAsync(new NtfyMessage
+        {
+            Message = "Only required values",
+            Title = null,
+            ClickUrl = null,
+            Tags = []
+        });
+
+        using var payload = JsonDocument.Parse(handler.RequestBody!);
+        var root = payload.RootElement;
+
+        Assert.IsFalse(root.TryGetProperty("title", out _));
+        Assert.IsFalse(root.TryGetProperty("click", out _));
+        Assert.IsFalse(root.TryGetProperty("tags", out _));
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("   ")]
+    public async Task PublishAsync_WithEmptyMessage_ThrowsArgumentException(string message)
+    {
+        var publisher = CreatePublisher(new FakeHttpMessageHandler());
+        var notification = new NtfyMessage { Message = message };
+
+        await Assert.ThrowsExactlyAsync<ArgumentException>(
+            () => publisher.PublishAsync(notification));
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_WithNullNotification_ThrowsArgumentNullException()
+    {
+        var publisher = CreatePublisher(new FakeHttpMessageHandler());
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(
+            () => publisher.PublishAsync(null!));
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_WithNonSuccessResponse_ThrowsHttpRequestException()
+    {
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.BadGateway);
+        var publisher = CreatePublisher(handler);
+
+        await Assert.ThrowsExactlyAsync<HttpRequestException>(
+            () => publisher.PublishAsync(new NtfyMessage { Message = "Hello" }));
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_WhenCancelled_PropagatesCancellationToHandler()
+    {
+        var handlerEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new FakeHttpMessageHandler(async (_, cancellationToken) =>
+        {
+            handlerEntered.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var publisher = CreatePublisher(handler);
+        using var cancellationSource = new CancellationTokenSource();
+
+        var publishTask = publisher.PublishAsync(
+            new NtfyMessage { Message = "Hello" },
+            cancellationSource.Token);
+        await handlerEntered.Task;
+        cancellationSource.Cancel();
+
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(() => publishTask);
+        Assert.IsTrue(handler.CancellationToken.IsCancellationRequested);
+    }
+
+    [TestMethod]
+    [DataRow(NtfyPriority.Min, 1)]
+    [DataRow(NtfyPriority.Low, 2)]
+    [DataRow(NtfyPriority.Default, 3)]
+    [DataRow(NtfyPriority.High, 4)]
+    [DataRow(NtfyPriority.Max, 5)]
+    public async Task PublishAsync_MapsPriorityToNtfyNumericValue(
+        NtfyPriority priority,
+        int expectedValue)
+    {
+        var handler = new FakeHttpMessageHandler();
+        var publisher = CreatePublisher(handler);
+
+        await publisher.PublishAsync(new NtfyMessage
+        {
+            Message = "Hello",
+            Priority = priority
+        });
+
+        using var payload = JsonDocument.Parse(handler.RequestBody!);
+        Assert.AreEqual(expectedValue, payload.RootElement.GetProperty("priority").GetInt32());
+    }
+
+    private static NtfyPublisher CreatePublisher(
+        FakeHttpMessageHandler handler,
+        string topic = "test-topic",
+        string? accessToken = null)
+    {
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new NtfyOptions
+        {
+            ServerUrl = ServerUrl,
+            Topic = topic,
+            AccessToken = accessToken
+        });
+
+        return new NtfyPublisher(httpClient, options);
+    }
+}

--- a/JoyfulReaperLib.Ntfy.Tests/ServiceCollectionExtensionsTests.cs
+++ b/JoyfulReaperLib.Ntfy.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Options;
+
+namespace JoyfulReaperLib.Ntfy.Tests;
+
+[TestClass]
+public sealed class ServiceCollectionExtensionsTests
+{
+    [TestMethod]
+    public void AddJoyfulReaperNtfy_WithConfigureAction_RegistersPublisher()
+    {
+        var services = new ServiceCollection();
+        services.AddJoyfulReaperNtfy(SetValidOptions);
+
+        using var provider = services.BuildServiceProvider();
+        var publisher = provider.GetRequiredService<INtfyPublisher>();
+
+        Assert.IsInstanceOfType<NtfyPublisher>(publisher);
+    }
+
+    [TestMethod]
+    public void AddJoyfulReaperNtfy_AppliesConfiguredTimeoutToTypedHttpClient()
+    {
+        var services = new ServiceCollection();
+        var expectedTimeout = TimeSpan.FromSeconds(37);
+        TimeSpan? observedTimeout = null;
+        services.AddJoyfulReaperNtfy(options =>
+        {
+            SetValidOptions(options);
+            options.Timeout = expectedTimeout;
+        });
+        services.ConfigureAll<HttpClientFactoryOptions>(options =>
+            options.HttpClientActions.Add(client => observedTimeout = client.Timeout));
+
+        using var provider = services.BuildServiceProvider();
+        _ = provider.GetRequiredService<INtfyPublisher>();
+
+        Assert.AreEqual(expectedTimeout, observedTimeout);
+    }
+
+    [TestMethod]
+    [DataRow("relative", "topic", 10)]
+    [DataRow("ftp://ntfy.example.test", "topic", 10)]
+    [DataRow("https://ntfy.example.test", "", 10)]
+    [DataRow("https://ntfy.example.test", "topic", 0)]
+    [DataRow("https://ntfy.example.test", "topic", -1)]
+    public void AddJoyfulReaperNtfy_WithInvalidOptions_FailsValidation(
+        string serverUrl,
+        string topic,
+        int timeoutSeconds)
+    {
+        var services = new ServiceCollection();
+        services.AddJoyfulReaperNtfy(options =>
+        {
+            options.ServerUrl = new Uri(serverUrl, UriKind.RelativeOrAbsolute);
+            options.Topic = topic;
+            options.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.ThrowsExactly<OptionsValidationException>(
+            () => _ = provider.GetRequiredService<IOptions<NtfyOptions>>().Value);
+    }
+
+    [TestMethod]
+    public void AddJoyfulReaperNtfy_WithConfiguration_BindsNtfySection()
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["Ntfy:ServerUrl"] = "https://configured.example.test/",
+            ["Ntfy:Topic"] = "configured-topic",
+            ["Ntfy:AccessToken"] = "tk_configured",
+            ["Ntfy:Timeout"] = "00:00:23"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+        var services = new ServiceCollection();
+
+        services.AddJoyfulReaperNtfy(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<NtfyOptions>>().Value;
+        Assert.AreEqual(new Uri("https://configured.example.test/"), options.ServerUrl);
+        Assert.AreEqual("configured-topic", options.Topic);
+        Assert.AreEqual("tk_configured", options.AccessToken);
+        Assert.AreEqual(TimeSpan.FromSeconds(23), options.Timeout);
+        Assert.IsInstanceOfType<NtfyPublisher>(provider.GetRequiredService<INtfyPublisher>());
+    }
+
+    private static void SetValidOptions(NtfyOptions options)
+    {
+        options.ServerUrl = new Uri("https://ntfy.example.test/");
+        options.Topic = "test-topic";
+    }
+}

--- a/JoyfulReaperLib.Ntfy/INtfyPublisher.cs
+++ b/JoyfulReaperLib.Ntfy/INtfyPublisher.cs
@@ -1,0 +1,8 @@
+﻿namespace JoyfulReaperLib.Ntfy;
+
+public interface INtfyPublisher
+{
+    Task PublishAsync(
+        NtfyMessage notification,
+        CancellationToken cancellationToken = default);
+}

--- a/JoyfulReaperLib.Ntfy/JoyfulReaperLib.Ntfy.csproj
+++ b/JoyfulReaperLib.Ntfy/JoyfulReaperLib.Ntfy.csproj
@@ -19,4 +19,8 @@
 		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="JoyfulReaperLib.Ntfy.Tests" />
+	</ItemGroup>
+
 </Project>

--- a/JoyfulReaperLib.Ntfy/JoyfulReaperLib.Ntfy.csproj
+++ b/JoyfulReaperLib.Ntfy/JoyfulReaperLib.Ntfy.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Copyright>Copyright 2026 Kyle Givler</Copyright>
+		<PackageProjectUrl>https://github.com/JoyfulReaper</PackageProjectUrl>
+		<PackageId>JoyfulReaperLib.Ntfy</PackageId>
+		<Version>0.0.1</Version>
+		<Authors>Kyle Givler</Authors>
+		<Description>Lightweight ntfy notification publishing for .NET applications.</Description>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+	</ItemGroup>
+
+</Project>

--- a/JoyfulReaperLib.Ntfy/NtfyMessage.cs
+++ b/JoyfulReaperLib.Ntfy/NtfyMessage.cs
@@ -1,0 +1,14 @@
+﻿namespace JoyfulReaperLib.Ntfy;
+
+public sealed record NtfyMessage
+{
+    public required string Message { get; init; }
+
+    public string? Title { get; init; }
+
+    public NtfyPriority Priority { get; init; } = NtfyPriority.Default;
+
+    public IReadOnlyCollection<string> Tags { get; init; } = [];
+
+    public Uri? ClickUrl { get; init; }
+}

--- a/JoyfulReaperLib.Ntfy/NtfyOptions.cs
+++ b/JoyfulReaperLib.Ntfy/NtfyOptions.cs
@@ -1,0 +1,25 @@
+﻿namespace JoyfulReaperLib.Ntfy;
+
+/*
+ {
+  "Ntfy": {
+    "ServerUrl": "https://ntfy.kgivler.com",
+    "Topic": "mission-control",
+    "AccessToken": "tk_replace_me",
+    "Timeout": "00:00:10"
+  }
+}
+*/
+
+public sealed class NtfyOptions
+{
+    public const string SectionName = "Ntfy";
+
+    public required Uri ServerUrl { get; set; }
+
+    public required string Topic { get; set; }
+
+    public string? AccessToken { get; set; }
+
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(10);
+}

--- a/JoyfulReaperLib.Ntfy/NtfyPriority.cs
+++ b/JoyfulReaperLib.Ntfy/NtfyPriority.cs
@@ -1,0 +1,10 @@
+﻿namespace JoyfulReaperLib.Ntfy;
+
+public enum NtfyPriority
+{
+    Min = 1,
+    Low = 2,
+    Default = 3,
+    High = 4,
+    Max = 5
+}

--- a/JoyfulReaperLib.Ntfy/NtfyPublisher.cs
+++ b/JoyfulReaperLib.Ntfy/NtfyPublisher.cs
@@ -1,0 +1,103 @@
+﻿using Microsoft.Extensions.Options;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace JoyfulReaperLib.Ntfy;
+
+internal sealed class NtfyPublisher : INtfyPublisher
+{
+    private static readonly JsonSerializerOptions JsonOptions =
+        new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+    private readonly HttpClient _httpClient;
+    private readonly NtfyOptions _options;
+
+    public NtfyPublisher(
+        HttpClient httpClient,
+        IOptions<NtfyOptions> options
+
+    )
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        _httpClient = httpClient;
+        _options = options.Value;
+    }
+
+    public async Task PublishAsync(
+        NtfyMessage notification,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        if (string.IsNullOrWhiteSpace(notification.Message))
+        {
+            throw new ArgumentException(
+                "Notification message cannot be empty.",
+                nameof(notification.Message)
+            );
+        }
+
+        var payload = new NtfyPublishRequest
+        {
+            Topic = _options.Topic,
+            Message = notification.Message,
+            Title = notification.Title,
+            Priority = (int)notification.Priority,
+            Tags = notification.Tags.Count > 0 ? notification.Tags : null,
+            Click = notification.ClickUrl?.AbsoluteUri
+        };
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            _options.ServerUrl)
+        {
+            Content = JsonContent.Create(payload, options: JsonOptions)
+        };
+
+        if(!string.IsNullOrWhiteSpace(_options.AccessToken))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                "Bearer",
+                _options.AccessToken
+            );
+        }
+
+        using var response = await _httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken
+        );
+
+        response.EnsureSuccessStatusCode();
+    }
+
+    private sealed record NtfyPublishRequest
+    {
+        [JsonPropertyName("topic")]
+        public required string Topic { get; init; }
+
+        [JsonPropertyName("message")]
+        public required string Message { get; init; }
+
+        [JsonPropertyName("title")]
+        public string? Title { get; init; }
+
+        [JsonPropertyName("priority")]
+        public int Priority { get; init; }
+
+        [JsonPropertyName("tags")]
+        public IReadOnlyCollection<string>? Tags { get; init; }
+
+        [JsonPropertyName("click")]
+        public string? Click { get; init; }
+    }
+}
+

--- a/JoyfulReaperLib.Ntfy/ServiceCollectionExtensions.cs
+++ b/JoyfulReaperLib.Ntfy/ServiceCollectionExtensions.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace JoyfulReaperLib.Ntfy;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddJoyfulReaperNtfy(
+        this IServiceCollection services,
+        Action<NtfyOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services
+            .AddOptions<NtfyOptions>()
+            .Configure(configure)
+            .Validate(
+                options =>
+                    options.ServerUrl is { IsAbsoluteUri: true } &&
+                    (options.ServerUrl.Scheme == Uri.UriSchemeHttp ||
+                     options.ServerUrl.Scheme == Uri.UriSchemeHttps),
+                $"{nameof(NtfyOptions.ServerUrl)} must be an absolute HTTP or HTTPS URL.")
+            .Validate(
+                options => !string.IsNullOrWhiteSpace(options.Topic),
+                $"{nameof(NtfyOptions.Topic)} cannot be empty.")
+            .Validate(
+                options => options.Timeout > TimeSpan.Zero,
+                $"{nameof(NtfyOptions.Timeout)} must be greater than zero.")
+            .ValidateOnStart();
+
+        services.AddHttpClient<INtfyPublisher, NtfyPublisher>(
+            static (serviceProvider, httpClient) =>
+            {
+                var options = serviceProvider
+                    .GetRequiredService<IOptions<NtfyOptions>>()
+                    .Value;
+
+                httpClient.Timeout = options.Timeout;
+            });
+
+        return services;
+    }
+
+    public static IServiceCollection AddJoyfulReaperNtfy(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return services.AddJoyfulReaperNtfy(options =>
+        {
+            configuration
+                .GetSection(NtfyOptions.SectionName)
+                .Bind(options);
+        });
+    }
+}

--- a/JoyfulReaperLib.Sqlite/JoyfulReaperLib.Sqlite.csproj
+++ b/JoyfulReaperLib.Sqlite/JoyfulReaperLib.Sqlite.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright 2022-2026 Kyle Givler</Copyright>
     <PackageProjectUrl>https://github.com/JoyfulReaper</PackageProjectUrl>
     <PackageId>JoyfulReaperLib.Sqlite</PackageId>
-    <Version>0.0.8</Version>
+    <Version>0.0.9</Version>
     <Authors>Kyle Givler</Authors>
     <Description>Shared SQLite provider initialization and connection string helpers for JoyfulReaperLib optional packages.</Description>
   </PropertyGroup>
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.9" />
     <PackageReference Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="SourceGear.sqlite3" Version="3.50.4.5" />
+    <PackageReference Include="SourceGear.sqlite3" Version="3.53.3" />
   </ItemGroup>
 
 </Project>

--- a/JoyfulReaperLib.Sqlite/SqliteDatabaseInitializer.cs
+++ b/JoyfulReaperLib.Sqlite/SqliteDatabaseInitializer.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Data.Sqlite;
+
+namespace JoyfulReaperLib.Sqlite;
+
+public static class SqliteDatabaseInitializer
+{
+    public static string Initialize(
+        string dbFileName,
+        string schemaSql,
+        string? basePath = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dbFileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaSql);
+
+        SqliteProviderInitializer.Initialize();
+
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = dbFileName,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Cache = SqliteCacheMode.Shared
+        }.ToString();
+
+        connectionString = SqliteConnectionStringHelper.Resolve(connectionString, basePath);
+
+        using var connection = new SqliteConnection(connectionString);
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = schemaSql;
+        command.ExecuteNonQuery();
+
+        return connectionString;
+    }
+}

--- a/JoyfulReaperLib.WebStats.Sqlite.Tests/JoyfulReaperLib.WebStats.Sqlite.Tests.csproj
+++ b/JoyfulReaperLib.WebStats.Sqlite.Tests/JoyfulReaperLib.WebStats.Sqlite.Tests.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/JoyfulReaperLib.WebStats.Sqlite/JoyfulReaperLib.WebStats.Sqlite.csproj
+++ b/JoyfulReaperLib.WebStats.Sqlite/JoyfulReaperLib.WebStats.Sqlite.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright 2022-2026 Kyle Givler</Copyright>
     <PackageProjectUrl>https://github.com/JoyfulReaper</PackageProjectUrl>
     <PackageId>JoyfulReaperLib.WebStats.Sqlite</PackageId>
-    <Version>0.0.8</Version>
+    <Version>0.0.9</Version>
     <Authors>Kyle Givler</Authors>
     <Description>SQLite-backed reusable hit counting and web stats for JoyfulReaperLib.</Description>
   </PropertyGroup>

--- a/JoyfulReaperLibTests/JoyfulReaperLib.Tests.csproj
+++ b/JoyfulReaperLibTests/JoyfulReaperLib.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/JoyfulReaperLibrary.sln
+++ b/JoyfulReaperLibrary.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoyfulReaperLib.MissionCont
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoyfulReaperLib.Ntfy", "JoyfulReaperLib.Ntfy\JoyfulReaperLib.Ntfy.csproj", "{F807BFD9-7B79-4FC9-B888-A39C8129869F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoyfulReaperLib.Ntfy.Tests", "JoyfulReaperLib.Ntfy.Tests\JoyfulReaperLib.Ntfy.Tests.csproj", "{42C35554-2588-4F58-87AB-95717F629C9C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -139,6 +141,18 @@ Global
 		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Release|x64.Build.0 = Release|Any CPU
 		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Release|x86.ActiveCfg = Release|Any CPU
 		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Release|x86.Build.0 = Release|Any CPU
+		{42C35554-2588-4F58-87AB-95717F629C9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42C35554-2588-4F58-87AB-95717F629C9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42C35554-2588-4F58-87AB-95717F629C9C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{42C35554-2588-4F58-87AB-95717F629C9C}.Debug|x64.Build.0 = Debug|Any CPU
+		{42C35554-2588-4F58-87AB-95717F629C9C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{42C35554-2588-4F58-87AB-95717F629C9C}.Debug|x86.Build.0 = Debug|Any CPU
+		{42C35554-2588-4F58-87AB-95717F629C9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42C35554-2588-4F58-87AB-95717F629C9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42C35554-2588-4F58-87AB-95717F629C9C}.Release|x64.ActiveCfg = Release|Any CPU
+		{42C35554-2588-4F58-87AB-95717F629C9C}.Release|x64.Build.0 = Release|Any CPU
+		{42C35554-2588-4F58-87AB-95717F629C9C}.Release|x86.ActiveCfg = Release|Any CPU
+		{42C35554-2588-4F58-87AB-95717F629C9C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/JoyfulReaperLibrary.sln
+++ b/JoyfulReaperLibrary.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.7.11925.98 stable
+VisualStudioVersion = 18.7.11925.98
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JoyfulReaperLib", "JoyfulReaperLibrary\JoyfulReaperLib.csproj", "{996E32D8-0CCF-4794-A962-52943BF0033E}"
 EndProject
@@ -16,6 +16,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoyfulReaperLib.WebStats.Sqlite", "JoyfulReaperLib.WebStats.Sqlite\JoyfulReaperLib.WebStats.Sqlite.csproj", "{A77DDEC1-E3E2-4830-9220-B5B4188C5192}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoyfulReaperLib.WebStats.Sqlite.Tests", "JoyfulReaperLib.WebStats.Sqlite.Tests\JoyfulReaperLib.WebStats.Sqlite.Tests.csproj", "{746BADD9-E003-45FF-ACB1-43433CE1BF60}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoyfulReaperLib.MissionControl", "JoyfulReaperLib.MissionControl\JoyfulReaperLib.MissionControl.csproj", "{574CB60D-0D22-454F-AF1D-064160D41FF9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -111,6 +113,18 @@ Global
 		{746BADD9-E003-45FF-ACB1-43433CE1BF60}.Release|x64.Build.0 = Release|Any CPU
 		{746BADD9-E003-45FF-ACB1-43433CE1BF60}.Release|x86.ActiveCfg = Release|Any CPU
 		{746BADD9-E003-45FF-ACB1-43433CE1BF60}.Release|x86.Build.0 = Release|Any CPU
+		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Debug|x64.Build.0 = Debug|Any CPU
+		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Debug|x86.Build.0 = Debug|Any CPU
+		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Release|x64.ActiveCfg = Release|Any CPU
+		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Release|x64.Build.0 = Release|Any CPU
+		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Release|x86.ActiveCfg = Release|Any CPU
+		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/JoyfulReaperLibrary.sln
+++ b/JoyfulReaperLibrary.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoyfulReaperLib.WebStats.Sq
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoyfulReaperLib.MissionControl", "JoyfulReaperLib.MissionControl\JoyfulReaperLib.MissionControl.csproj", "{574CB60D-0D22-454F-AF1D-064160D41FF9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JoyfulReaperLib.Ntfy", "JoyfulReaperLib.Ntfy\JoyfulReaperLib.Ntfy.csproj", "{F807BFD9-7B79-4FC9-B888-A39C8129869F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +127,18 @@ Global
 		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Release|x64.Build.0 = Release|Any CPU
 		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Release|x86.ActiveCfg = Release|Any CPU
 		{574CB60D-0D22-454F-AF1D-064160D41FF9}.Release|x86.Build.0 = Release|Any CPU
+		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Debug|x64.Build.0 = Debug|Any CPU
+		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Debug|x86.Build.0 = Debug|Any CPU
+		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Release|x64.ActiveCfg = Release|Any CPU
+		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Release|x64.Build.0 = Release|Any CPU
+		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Release|x86.ActiveCfg = Release|Any CPU
+		{F807BFD9-7B79-4FC9-B888-A39C8129869F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/JoyfulReaperLibrary/JRNet/IPAddressUtils.cs
+++ b/JoyfulReaperLibrary/JRNet/IPAddressUtils.cs
@@ -1,0 +1,34 @@
+﻿using System.Net;
+
+namespace JoyfulReaperLib.JRNet;
+
+public static class IPAddressUtils
+{
+    /// <summary>
+    /// Parses a string representation of an IP address, handling common wildcards.
+    /// </summary>
+    /// <param name="value">The string address format (e.g., "*", "0.0.0.0", "::", or an explicit IP).</param>
+    /// <param name="libraryName">Optional library name to include in the exception message if parsing fails.</param>
+    /// <returns>An <see cref="IPAddress"/> mapped to the appropriate listener configuration.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the string cannot be parsed into a valid IP address.</exception>
+    public static IPAddress ParseListenAddress(string value, string? libraryName = null)
+    {
+        if (value is "*" or "+" or "0.0.0.0")
+        {
+            return IPAddress.Any;
+        }
+
+        if (value == "::")
+        {
+            return IPAddress.IPv6Any;
+        }
+
+        if (!IPAddress.TryParse(value, out IPAddress? address))
+        {
+            string prefix = !string.IsNullOrWhiteSpace(libraryName) ? $"{libraryName}: " : string.Empty;
+            throw new InvalidOperationException($"{prefix}Invalid listen address: {value}.");
+        }
+
+        return address;
+    }
+}

--- a/JoyfulReaperLibrary/JoyfulReaperLib.csproj
+++ b/JoyfulReaperLibrary/JoyfulReaperLib.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright 2022-2026 Kyle Givler</Copyright>
     <PackageProjectUrl>https://github.com/JoyfulReaper</PackageProjectUrl>
 	<PackageId>JoyfulReaperLib</PackageId>
-	<Version>0.0.9</Version>
+	<Version>0.0.11</Version>
 	<Authors>Kyle Givler</Authors>
 	<Description>Lightweight shared utility helpers.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Packages:
 - `JoyfulReaperLib.Caching.Sqlite`
 - `JoyfulReaperLib.WebStats.Sqlite`
 - `JoyfulReaperLib.MissionControl`
+- `JoyfulReaperLib.Ntfy`
 
 Base package:
 
-`JoyfulReaperLib` is the lightweight base package for shared utility helpers. Optional SQLite-backed caching, provider initialization, and web stats features live in the separate `JoyfulReaperLib.Sqlite`, `JoyfulReaperLib.Caching.Sqlite`, and `JoyfulReaperLib.WebStats.Sqlite` packages.
+`JoyfulReaperLib` is the lightweight base package for shared utility helpers. Optional SQLite-backed caching, provider initialization, and web stats features live in the separate `JoyfulReaperLib.Sqlite`, `JoyfulReaperLib.Caching.Sqlite`, and `JoyfulReaperLib.WebStats.Sqlite` packages. ntfy support lives in its own optional `JoyfulReaperLib.Ntfy` package.
 
 Install:
 
@@ -19,6 +20,7 @@ Install:
 dotnet add package JoyfulReaperLib
 dotnet add package JoyfulReaperLib.Caching.Sqlite
 dotnet add package JoyfulReaperLib.WebStats.Sqlite
+dotnet add package JoyfulReaperLib.Ntfy
 ```
 
 `JoyfulReaperLib.Sqlite` is usually pulled in transitively unless your app directly uses `SqliteProviderInitializer` or `SqliteConnectionStringHelper`.
@@ -28,6 +30,7 @@ dotnet add package JoyfulReaperLib.WebStats.Sqlite
 `JoyfulReaperLib.Caching.Sqlite` provides a SQLite-backed `IDistributedCache`.
 `JoyfulReaperLib.WebStats.Sqlite` provides SQLite-backed reusable web stats and hit counting.
 `JoyfulReaperLib.MissionControl` provides a best-effort HTTP client for publishing application events to Mission Control.
+`JoyfulReaperLib.Ntfy` publishes notifications to hosted or self-hosted ntfy servers. It supports bearer-token authentication, titles, priorities, tags, click URLs, cancellation, configurable timeouts, and dependency injection.
 
 Caching:
 
@@ -49,4 +52,53 @@ services.AddJoyfulReaperSqliteHitCounter(options =>
 
 ```csharp
 var stats = await hitCounter.RecordHitAsync(visitorKey);
+```
+
+## Ntfy notifications
+
+### Registration
+
+```csharp
+builder.Services.AddJoyfulReaperNtfy(builder.Configuration);
+```
+
+### Configuration
+
+```json
+{
+  "Ntfy": {
+    "ServerUrl": "https://ntfy.example.com",
+    "Topic": "application-alerts",
+    "Timeout": "00:00:10"
+  }
+}
+```
+
+The access token should normally be supplied through an environment variable rather than committed to configuration:
+
+```text
+Ntfy__AccessToken=tk_your_token_here
+```
+
+`ServerUrl` should contain only the ntfy server root. The topic is configured separately through `NtfyOptions.Topic`. Invalid server URL, topic, and timeout configuration is validated during application startup.
+
+### Publishing
+
+```csharp
+public sealed class AlertService(INtfyPublisher publisher)
+{
+    public Task SendAsync(CancellationToken cancellationToken)
+    {
+        return publisher.PublishAsync(
+            new NtfyMessage
+            {
+                Title = "Application alert",
+                Message = "The application requires attention.",
+                Priority = NtfyPriority.High,
+                Tags = ["warning", "computer"],
+                ClickUrl = new Uri("https://example.com/status")
+            },
+            cancellationToken);
+    }
+}
 ```

--- a/README.md
+++ b/README.md
@@ -1,64 +1,205 @@
 # JoyfulReaperLib
-A library of code that I have found helpful!
 
-Packages:
+A collection of lightweight .NET helpers and optional packages for SQLite storage, web statistics, Mission Control events, and ntfy notifications.
 
-- `JoyfulReaperLib`
-- `JoyfulReaperLib.Sqlite`
-- `JoyfulReaperLib.Caching.Sqlite`
-- `JoyfulReaperLib.WebStats.Sqlite`
-- `JoyfulReaperLib.MissionControl`
-- `JoyfulReaperLib.Ntfy`
+## Packages
 
-Base package:
+| Package | Description |
+| --- | --- |
+| `JoyfulReaperLib` | Shared helpers for text, numbers, collections, serialization, validation, encryption, console output, and other common tasks. |
+| `JoyfulReaperLib.Sqlite` | Shared SQLite provider initialization, database initialization, and connection-string path handling. |
+| `JoyfulReaperLib.Caching.Sqlite` | A SQLite-backed implementation of `IDistributedCache`. |
+| `JoyfulReaperLib.WebStats.Sqlite` | SQLite-backed hit counting and unique-visitor statistics. |
+| `JoyfulReaperLib.MissionControl` | A best-effort HTTP client for publishing application events to Mission Control. |
+| `JoyfulReaperLib.Ntfy` | An HTTP client for publishing notifications to hosted or self-hosted ntfy servers. |
 
-`JoyfulReaperLib` is the lightweight base package for shared utility helpers. Optional SQLite-backed caching, provider initialization, and web stats features live in the separate `JoyfulReaperLib.Sqlite`, `JoyfulReaperLib.Caching.Sqlite`, and `JoyfulReaperLib.WebStats.Sqlite` packages. ntfy support lives in its own optional `JoyfulReaperLib.Ntfy` package.
+`JoyfulReaperLib` is the lightweight base package. SQLite features, Mission Control integration, and ntfy support live in separate optional packages so applications only take the dependencies they need.
 
-Install:
+## Installation
+
+Install the packages your application uses:
 
 ```bash
 dotnet add package JoyfulReaperLib
+dotnet add package JoyfulReaperLib.Sqlite
 dotnet add package JoyfulReaperLib.Caching.Sqlite
 dotnet add package JoyfulReaperLib.WebStats.Sqlite
+dotnet add package JoyfulReaperLib.MissionControl
 dotnet add package JoyfulReaperLib.Ntfy
 ```
 
-`JoyfulReaperLib.Sqlite` is usually pulled in transitively unless your app directly uses `SqliteProviderInitializer` or `SqliteConnectionStringHelper`.
+`JoyfulReaperLib.Sqlite` is pulled in transitively by the SQLite caching and web stats packages. Install it directly when using `SqliteProviderInitializer`, `SqliteDatabaseInitializer`, or `SqliteConnectionStringHelper` in application code.
 
-`JoyfulReaperLib` is the lightweight base package with no SQLite dependencies.
-`JoyfulReaperLib.Sqlite` provides shared SQLite provider initialization for optional SQLite-based packages.
-`JoyfulReaperLib.Caching.Sqlite` provides a SQLite-backed `IDistributedCache`.
-`JoyfulReaperLib.WebStats.Sqlite` provides SQLite-backed reusable web stats and hit counting.
-`JoyfulReaperLib.MissionControl` provides a best-effort HTTP client for publishing application events to Mission Control.
-`JoyfulReaperLib.Ntfy` publishes notifications to hosted or self-hosted ntfy servers. It supports bearer-token authentication, titles, priorities, tags, click URLs, cancellation, configurable timeouts, and dependency injection.
+## JoyfulReaperLib
 
-Caching:
+The base package contains dependency-free utility APIs, including:
+
+- string reversal, palindrome checks, text analysis, and greedy line wrapping;
+- numeric helpers, base conversion, Fibonacci sequences, and Luhn validation;
+- random item selection for arrays and lists;
+- JSON byte-array serialization;
+- URL and IP address validation;
+- currency, enum, console, Caesar cipher, and Vigenere cipher helpers.
+
+Example:
 
 ```csharp
-services.AddJoyfulReaperSqliteDistributedCache(options =>
+using JoyfulReaperLib.JRNumbers;
+using JoyfulReaperLib.JRSerialization;
+using JoyfulReaperLib.JRText;
+
+string reversed = StringHelper.Reverse("Joyful");
+string binary = BaseConverter.DecimalToBinary(42);
+
+byte[]? bytes = JsonByteArraySerializer.SerializeToUtf8Bytes(new
 {
-    options.ConnectionString = "Data Source=cache.db";
+    Name = "example",
+    Count = 2
 });
 ```
 
-Web stats:
+## JoyfulReaperLib.Sqlite
+
+This package configures the bundled SQLite provider and provides helpers for resolving database paths and initializing a database schema.
 
 ```csharp
-services.AddJoyfulReaperSqliteHitCounter(options =>
-{
-    options.ConnectionString = "Data Source=app-stats.db";
-});
+using JoyfulReaperLib.Sqlite;
+
+string connectionString = SqliteDatabaseInitializer.Initialize(
+    dbFileName: "application.db",
+    schemaSql: """
+        CREATE TABLE IF NOT EXISTS Settings (
+            Key TEXT PRIMARY KEY,
+            Value TEXT NOT NULL
+        );
+        """,
+    basePath: "Data");
 ```
 
-```csharp
-var stats = await hitCounter.RecordHitAsync(visitorKey);
-```
+`SqliteProviderInitializer.Initialize()` is safe to call more than once. `SqliteConnectionStringHelper.Resolve(...)` leaves `:memory:` and `file:` data sources unchanged. Relative file paths use the supplied base path, or the application's `Data` directory when no base path is supplied.
 
-## Ntfy notifications
+## JoyfulReaperLib.Caching.Sqlite
+
+This package registers a SQLite-backed `IDistributedCache` with support for absolute and sliding expiration.
 
 ### Registration
 
 ```csharp
+using JoyfulReaperLib.Caching.Sqlite;
+
+builder.Services.AddJoyfulReaperSqliteDistributedCache(options =>
+{
+    options.ConnectionString = "Data Source=cache.db";
+    options.BasePath = "Data";
+});
+```
+
+Provider initialization and database creation are handled automatically.
+
+### Usage
+
+```csharp
+using Microsoft.Extensions.Caching.Distributed;
+
+await cache.SetStringAsync(
+    "status",
+    "ready",
+    new DistributedCacheEntryOptions
+    {
+        SlidingExpiration = TimeSpan.FromMinutes(10)
+    },
+    cancellationToken);
+
+string? status = await cache.GetStringAsync("status", cancellationToken);
+```
+
+## JoyfulReaperLib.WebStats.Sqlite
+
+This package provides an `IHitCounter` that tracks total hits and unique visitor keys in SQLite.
+
+### Registration
+
+```csharp
+using JoyfulReaperLib.WebStats.Sqlite;
+
+builder.Services.AddJoyfulReaperSqliteHitCounter(options =>
+{
+    options.ConnectionString = "Data Source=web-stats.db";
+    options.BasePath = "Data";
+});
+```
+
+Provider initialization and database creation are handled automatically.
+
+### Usage
+
+```csharp
+HitCountStats stats = await hitCounter.RecordHitAsync(
+    visitorKey,
+    cancellationToken);
+
+Console.WriteLine($"{stats.TotalHits} hits from {stats.UniqueVisitors} visitors");
+
+HitCountStats current = await hitCounter.GetHitCountsAsync(cancellationToken);
+```
+
+The application chooses the visitor key. Avoid storing personal information unless your application's privacy requirements allow it.
+
+## JoyfulReaperLib.MissionControl
+
+This package publishes structured application events to the Mission Control `api/events` endpoint. Publishing is best effort: `TryPublishAsync` returns `false` when the client is disabled, the request is cancelled, the request times out, or the server cannot accept the event.
+
+### Registration
+
+```csharp
+using JoyfulReaperLib.MissionControl;
+
+builder.Services.AddMissionControlClient(
+    builder.Configuration.GetSection(MissionControlClientOptions.SectionName));
+```
+
+### Configuration
+
+```json
+{
+  "MissionControl": {
+    "Enabled": true,
+    "BaseUrl": "https://mission-control.example.com/",
+    "TimeoutMilliseconds": 1000
+  }
+}
+```
+
+Supply the API key through an environment variable rather than committing it:
+
+```text
+MissionControl__ApiKey=replace_with_at_least_32_characters
+```
+
+Optional Cloudflare Access credentials can be provided through `MissionControl__CloudflareAccessClientId` and `MissionControl__CloudflareAccessClientSecret`.
+
+When enabled, the base URL must be an absolute HTTP or HTTPS URL, the API key must contain at least 32 characters, and the timeout must be between 100 and 10,000 milliseconds. These settings are validated during application startup.
+
+### Publishing
+
+```csharp
+bool published = await missionControlClient.TryPublishAsync(
+    eventType: "application.started",
+    payload: new { Environment = "Production" },
+    occurredAt: DateTimeOffset.UtcNow,
+    correlationId: null,
+    cancellationToken: cancellationToken);
+```
+
+## JoyfulReaperLib.Ntfy
+
+This package publishes notifications to hosted or self-hosted ntfy servers. It supports bearer-token authentication, titles, priorities, tags, click URLs, cancellation, configurable timeouts, and dependency injection.
+
+### Registration
+
+```csharp
+using JoyfulReaperLib.Ntfy;
+
 builder.Services.AddJoyfulReaperNtfy(builder.Configuration);
 ```
 
@@ -74,13 +215,13 @@ builder.Services.AddJoyfulReaperNtfy(builder.Configuration);
 }
 ```
 
-The access token should normally be supplied through an environment variable rather than committed to configuration:
+Supply the access token through an environment variable rather than committing it:
 
 ```text
 Ntfy__AccessToken=tk_your_token_here
 ```
 
-`ServerUrl` should contain only the ntfy server root. The topic is configured separately through `NtfyOptions.Topic`. Invalid server URL, topic, and timeout configuration is validated during application startup.
+`ServerUrl` should contain only the ntfy server root. The topic is configured separately through `NtfyOptions.Topic`. Invalid server URL, topic, and timeout settings are validated during application startup.
 
 ### Publishing
 
@@ -102,3 +243,18 @@ public sealed class AlertService(INtfyPublisher publisher)
     }
 }
 ```
+
+Priority values map directly to ntfy priorities: `Min`, `Low`, `Default`, `High`, and `Max` map to numeric values 1 through 5.
+
+## Development
+
+Build and test the complete solution with:
+
+```powershell
+dotnet build JoyfulReaperLibrary.sln
+dotnet test JoyfulReaperLibrary.sln
+```
+
+## License
+
+JoyfulReaperLib is available under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A collection of lightweight .NET helpers and optional packages for SQLite storage, web statistics, Mission Control events, and ntfy notifications.
 
+> [!IMPORTANT]
+> These packages are not currently published to NuGet.org. The package names below identify the projects and their intended package IDs, but `dotnet add package` will not install them from the public NuGet feed yet.
+
 ## Packages
 
 | Package | Description |
@@ -15,20 +18,20 @@ A collection of lightweight .NET helpers and optional packages for SQLite storag
 
 `JoyfulReaperLib` is the lightweight base package. SQLite features, Mission Control integration, and ntfy support live in separate optional packages so applications only take the dependencies they need.
 
-## Installation
+## Using the projects locally
 
-Install the packages your application uses:
+Clone this repository and add project references from your application to the projects it uses. Replace `path/to/YourApp.csproj` with your application's project path:
 
 ```bash
-dotnet add package JoyfulReaperLib
-dotnet add package JoyfulReaperLib.Sqlite
-dotnet add package JoyfulReaperLib.Caching.Sqlite
-dotnet add package JoyfulReaperLib.WebStats.Sqlite
-dotnet add package JoyfulReaperLib.MissionControl
-dotnet add package JoyfulReaperLib.Ntfy
+dotnet add path/to/YourApp.csproj reference JoyfulReaperLibrary/JoyfulReaperLib.csproj
+dotnet add path/to/YourApp.csproj reference JoyfulReaperLib.Sqlite/JoyfulReaperLib.Sqlite.csproj
+dotnet add path/to/YourApp.csproj reference JoyfulReaperLib.Caching.Sqlite/JoyfulReaperLib.Caching.Sqlite.csproj
+dotnet add path/to/YourApp.csproj reference JoyfulReaperLib.WebStats.Sqlite/JoyfulReaperLib.WebStats.Sqlite.csproj
+dotnet add path/to/YourApp.csproj reference JoyfulReaperLib.MissionControl/JoyfulReaperLib.MissionControl.csproj
+dotnet add path/to/YourApp.csproj reference JoyfulReaperLib.Ntfy/JoyfulReaperLib.Ntfy.csproj
 ```
 
-`JoyfulReaperLib.Sqlite` is pulled in transitively by the SQLite caching and web stats packages. Install it directly when using `SqliteProviderInitializer`, `SqliteDatabaseInitializer`, or `SqliteConnectionStringHelper` in application code.
+Only add the references your application needs. `JoyfulReaperLib.Sqlite` is referenced transitively by the SQLite caching and web stats projects. Reference it directly when using `SqliteProviderInitializer`, `SqliteDatabaseInitializer`, or `SqliteConnectionStringHelper` in application code.
 
 ## JoyfulReaperLib
 
@@ -41,21 +44,150 @@ The base package contains dependency-free utility APIs, including:
 - URL and IP address validation;
 - currency, enum, console, Caesar cipher, and Vigenere cipher helpers.
 
-Example:
+### Text helpers
 
 ```csharp
-using JoyfulReaperLib.JRNumbers;
-using JoyfulReaperLib.JRSerialization;
 using JoyfulReaperLib.JRText;
 
 string reversed = StringHelper.Reverse("Joyful");
-string binary = BaseConverter.DecimalToBinary(42);
+bool palindrome = StringHelper.IsPalindrome("neveroddoreven");
+string? optionalValue = StringHelper.AssignNullIfEmpty("   ");
 
-byte[]? bytes = JsonByteArraySerializer.SerializeToUtf8Bytes(new
+var wrapper = new GreedyWrap(
+    lineWidth: 30,
+    wrapWordsLongerThanLineWidth: true)
 {
-    Name = "example",
-    Count = 2
-});
+    TabWidth = 4
+};
+
+string wrapped = wrapper.LineWrap(
+    "A long line of text that should be wrapped for display.");
+```
+
+`StringHelper.VowelAnalysis(...)` also returns the vowel count while reporting consonants, whitespace, numbers, and unknown characters through `out` parameters.
+
+### Collections and enums
+
+```csharp
+using JoyfulReaperLib.JRArray;
+using JoyfulReaperLib.JREnums;
+using JoyfulReaperLib.JRLists;
+
+string randomFromArray = new[] { "red", "green", "blue" }.RandomItem();
+int randomFromList = new List<int> { 10, 20, 30 }.RandomItem();
+
+DayOfWeek randomDay = EnumHelper.RandomEnumValue<DayOfWeek>();
+bool validDay = EnumHelper.EnumValueIsValid(DayOfWeek.Monday);
+(long min, long max) = EnumHelper.GetEnumMinMax<DayOfWeek>();
+```
+
+Random item selection throws when the source collection is empty.
+
+### Numbers and algorithms
+
+```csharp
+using JoyfulReaperLib.JRAlgorithms;
+using JoyfulReaperLib.JRMath;
+using JoyfulReaperLib.JRNumbers;
+
+int digits = NumberHelper.NumberOfDigits(12345);
+string binary = BaseConverter.DecimalToBinary(42);
+int decimalValue = BaseConverter.BinaryToDecimal("101010");
+
+long[] sequence = Fibonacci.FibonacciSequence(
+    first: 0,
+    second: 1,
+    term: 10);
+
+string completedNumber = Luhn.LuhnCreate("7992739871", out int checkDigit);
+bool valid = Luhn.LuhnValidate(completedNumber);
+string cardNumber = "4111111111111111";
+bool validVisa = Luhn.LuhnValidate(cardNumber, Luhn.CheckType.Visa);
+```
+
+### JSON byte-array serialization
+
+```csharp
+using JoyfulReaperLib.JRSerialization;
+
+var original = new Dictionary<string, int>
+{
+    ["apples"] = 3,
+    ["oranges"] = 2
+};
+
+byte[]? bytes = JsonByteArraySerializer.SerializeToUtf8Bytes(original);
+Dictionary<string, int>? restored =
+    JsonByteArraySerializer.DeserializeFromUtf8Bytes<Dictionary<string, int>>(bytes);
+```
+
+Null values serialize to `null`, and null or empty byte arrays deserialize to the default value for the requested type.
+
+### URL and listen-address validation
+
+```csharp
+using System.Net;
+using JoyfulReaperLib.JRNet;
+
+bool validUrl = UrlValidator.ValidateUrl("https://example.com/status");
+
+IPAddress anyAddress = IPAddressUtils.ParseListenAddress("*");
+IPAddress loopback = IPAddressUtils.ParseListenAddress("127.0.0.1");
+```
+
+`ParseListenAddress` maps `*`, `+`, and `0.0.0.0` to `IPAddress.Any`, and maps `::` to `IPAddress.IPv6Any`.
+
+### Currency helpers
+
+```csharp
+using JoyfulReaperLib.JRCurrency;
+
+List<CurrencyUnit> coins = CurrencyHelper.GetUSDCommonCoins();
+List<CurrencyUnit> change = CurrencyHelper.CalculateChange(0.41m, coins);
+
+foreach (CurrencyUnit unit in change)
+{
+    Console.WriteLine($"{unit.Quantity} {unit.PluralName}");
+}
+```
+
+`CalculateChange` uses a greedy algorithm and throws if the requested amount cannot be represented by the supplied units.
+
+### Classical ciphers
+
+```csharp
+using JoyfulReaperLib.JREncryption;
+
+string caesar = CipherHelper.CaesarEncipher("Meet at noon", key: 3);
+string original = CipherHelper.CaesarDecipher(caesar, key: 3);
+
+string vigenere = CipherHelper.VigenereCipher(
+    text: "ATTACKATDAWN",
+    key: "LEMON",
+    dir: CipherHelper.Direction.Encipher);
+```
+
+These are educational classical ciphers and are not suitable for passwords, secrets, or other security-sensitive data.
+
+### Console output
+
+```csharp
+using JoyfulReaperLib.JRConsole;
+
+ConsoleHelper.ColorWriteLine(ConsoleColor.Green, "Operation completed.");
+
+ConsoleHelper.MulticolorWriteLine(
+    new List<ConsoleColor>
+    {
+        ConsoleColor.Cyan,
+        ConsoleColor.Magenta
+    },
+    "Alternating colors");
+
+int choice = ConsoleHelper.GetValidInt(
+    prompt: "Choose a value: ",
+    min: 1,
+    max: 10);
 ```
 
 ## JoyfulReaperLib.Sqlite

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Packages:
 - `JoyfulReaperLib.Sqlite`
 - `JoyfulReaperLib.Caching.Sqlite`
 - `JoyfulReaperLib.WebStats.Sqlite`
+- `JoyfulReaperLib.MissionControl`
 
 Base package:
 
@@ -26,6 +27,7 @@ dotnet add package JoyfulReaperLib.WebStats.Sqlite
 `JoyfulReaperLib.Sqlite` provides shared SQLite provider initialization for optional SQLite-based packages.
 `JoyfulReaperLib.Caching.Sqlite` provides a SQLite-backed `IDistributedCache`.
 `JoyfulReaperLib.WebStats.Sqlite` provides SQLite-backed reusable web stats and hit counting.
+`JoyfulReaperLib.MissionControl` provides a best-effort HTTP client for publishing application events to Mission Control.
 
 Caching:
 


### PR DESCRIPTION
## Summary

This PR merges the latest `dev` changes into `main`, adding new Mission Control and ntfy integrations alongside SQLite and networking improvements.

## Changes

### Mission Control

- Adds the `JoyfulReaperLib.MissionControl` package.
- Provides a best-effort `IMissionControlClient` for publishing structured application events.
- Supports configuration binding, dependency injection, configurable timeouts, API-key authentication, and optional Cloudflare Access headers.
- Validates URL, API key, and timeout settings during application startup.
- Returns `false` when publishing is disabled, cancelled, times out, or otherwise fails.

### ntfy notifications

- Adds the `JoyfulReaperLib.Ntfy` package.
- Supports hosted and self-hosted ntfy servers.
- Supports bearer-token authentication, titles, numeric priorities, tags, click URLs, cancellation, and configurable timeouts.
- Adds configuration and dependency-injection extensions.
- Validates the server URL, topic, and timeout during startup.
- Adds 25 deterministic tests using a fake HTTP handler with no live network requests.

### Shared library and SQLite

- Adds `IPAddressUtils.ParseListenAddress` for explicit and wildcard listen addresses.
- Adds `SqliteDatabaseInitializer` for provider initialization, database creation, and schema setup.
- Updates SQLite dependencies and package versions.
- Updates MSTest packages to 4.3.0.

### Documentation

- Rewrites the root README with documentation and examples for all six packages.
- Adds expanded examples for the base utility library.
- Documents local project references and clearly notes that the packages are not currently published to NuGet.org.
- Uses placeholder hosts and credentials in all public examples.

## Validation

- [x] `dotnet build JoyfulReaperLibrary.sln`
  - 0 warnings
  - 0 errors
- [x] `dotnet test JoyfulReaperLibrary.sln`
  - 88 passed
  - 0 failed
  - 0 skipped

## Notes

- No packages are published to NuGet.org as part of this PR.
- No live Mission Control or ntfy services are contacted by the automated tests.